### PR TITLE
Gql/setup playground

### DIFF
--- a/graphql/index.js
+++ b/graphql/index.js
@@ -11,18 +11,6 @@ mongoose.Promise = global.Promise;
 mongoose.connect(url, { useNewUrlParser: true });
 mongoose.connection.once('open', () => console.log(`Connected to mongo at ${url}`));
 
-// const typeDefs = gql`
-//   type Query {
-//     hello: String
-//   }
-// `;
-
-// const resolvers = {
-//   Query: {
-//     hello: () => 'hello World!',
-//   },
-// };
-
 const server = new ApolloServer({
   typeDefs,
   resolvers,

--- a/graphql/index.js
+++ b/graphql/index.js
@@ -1,38 +1,34 @@
-import express from "express";
-import expressGraphQL from "express-graphql";
-import mongoose from "mongoose";
-import bodyParser from "body-parser";
-import cors from "cors";
-import opn from "open";
+const express               = require('express');
+const { ApolloServer, gql } = require('apollo-server-express');
 const app = express();
-const PORT = process.env.PORT || "4000";
-const db = "mongodb://harry:Sophie777@ds052968.mlab.com:52968/lunch";
-import schema from "./schema/index";
+const mongoose = require('mongoose');
+const url = "mongodb://harry:Sophie777@ds052968.mlab.com:52968/lunch";
+// const { typeDefs, resolvers } = require("./schema/index");
 
+mongoose.Promise = global.Promise;
+mongoose.connect(url, { useNewUrlParser: true });
+mongoose.connection.once('open', () => console.log(`Connected to mongo at ${url}`));
 
-// Connect to MongoDB with Mongoose.
-mongoose
-  .connect(
-    db,
-    {
-      useCreateIndex: true,
-      useNewUrlParser: true
-    }
-  )
-  .then(() => console.log("MongoDB connected"))
-  .catch(err => console.log(err));
+const typeDefs = gql`
+  type Query {
+    hello: String
+  }
+`;
 
-  app.use(
-    "/graphql",
-    cors(),
-    bodyParser.json(),
-    expressGraphQL({
-      schema,
-      graphiql: true
-    })
-  );
+const resolvers = {
+  Query: {
+    hello: () => 'hello',
+  },
+};
 
-  app.listen(PORT, () =>
-    console.log(`Server running on port localhost:${PORT}/graphql`),
-    // opn('http://localhost:4000/graphql')
-  );
+const server = new ApolloServer({
+  typeDefs,
+  resolvers,
+  introspection: true,
+  playground: true,
+});
+server.applyMiddleware({ app });
+
+app.listen({ port: 4000 }, () =>
+  console.log(`🚀 Server ready at http://localhost:4000/graphql`)
+);

--- a/graphql/index.js
+++ b/graphql/index.js
@@ -1,25 +1,27 @@
-const express               = require('express');
-const { ApolloServer, gql } = require('apollo-server-express');
+const express = require('express');
 const app = express();
+const { ApolloServer, gql } = require('apollo-server-express');
 const mongoose = require('mongoose');
 const url = "mongodb://harry:Sophie777@ds052968.mlab.com:52968/lunch";
-// const { typeDefs, resolvers } = require("./schema/index");
+
+const typeDefs = require("./schema/types");
+const resolvers = require("./schema/resolvers");
 
 mongoose.Promise = global.Promise;
 mongoose.connect(url, { useNewUrlParser: true });
 mongoose.connection.once('open', () => console.log(`Connected to mongo at ${url}`));
 
-const typeDefs = gql`
-  type Query {
-    hello: String
-  }
-`;
+// const typeDefs = gql`
+//   type Query {
+//     hello: String
+//   }
+// `;
 
-const resolvers = {
-  Query: {
-    hello: () => 'hello',
-  },
-};
+// const resolvers = {
+//   Query: {
+//     hello: () => 'hello World!',
+//   },
+// };
 
 const server = new ApolloServer({
   typeDefs,

--- a/graphql/schema/index.js
+++ b/graphql/schema/index.js
@@ -1,11 +1,11 @@
-import { makeExecutableSchema } from "graphql-tools";
+const { makeExecutableSchema } = require("graphql-tools");
 
-import typeDefs from "./types/";
-import resolvers from "./resolvers/";
+const typeDefs = require("./types/");
+const resolvers = require("./resolvers/");
 
 const schema = makeExecutableSchema({
   typeDefs,
   resolvers
 });
 
-export default schema;
+module.exports = schema;

--- a/graphql/schema/resolvers/Eatery/index.js
+++ b/graphql/schema/resolvers/Eatery/index.js
@@ -1,7 +1,7 @@
 // The Eatery schema
-import Eatery from "../../../server/models/Eatery";
+const Eatery = require("../../../server/models/Eatery");
 
-export default {
+module.exports = {
   Query: {
     eatery: (root, args) => {
       return new Promise((resolve, reject) => {

--- a/graphql/schema/resolvers/User/index.js
+++ b/graphql/schema/resolvers/User/index.js
@@ -1,7 +1,7 @@
 // The User schema
-import User from "../../../server/models/User";
+const User = require("../../../server/models/User");
 
-export default {
+module.exports = {
   Query: {
     user: (root, args) => {
       return new Promise((resolve, reject) => {

--- a/graphql/schema/resolvers/index.js
+++ b/graphql/schema/resolvers/index.js
@@ -1,8 +1,8 @@
-import { mergeResolvers } from "merge-graphql-schemas";
+const { mergeResolvers } = require("merge-graphql-schemas");
 
-import User from "./User/";
-import Eatery from "./Eatery/";
+const User = require("./User/");
+const Eatery = require("./Eatery/");
 
 const resolvers = [User, Eatery];
 
-export default mergeResolvers(resolvers);
+module.exports = mergeResolvers(resolvers);

--- a/graphql/schema/types/Eatery/index.js
+++ b/graphql/schema/types/Eatery/index.js
@@ -1,4 +1,4 @@
-export default `
+module.exports = `
   type Eatery {
     id: String!
     name: String!

--- a/graphql/schema/types/User/index.js
+++ b/graphql/schema/types/User/index.js
@@ -1,4 +1,4 @@
-export default `
+module.exports = `
   type User {
     id: String!
     name: String!

--- a/graphql/schema/types/index.js
+++ b/graphql/schema/types/index.js
@@ -1,8 +1,8 @@
-import { mergeTypes } from "merge-graphql-schemas";
+const { mergeTypes } = require("merge-graphql-schemas");
 
-import User from "./User/";
-import Eatery from "./Eatery/";
+const User = require("./User/");
+const Eatery = require("./Eatery/");
 
 const typeDefs = [User, Eatery];
 
-export default mergeTypes(typeDefs, { all: true });
+module.exports = mergeTypes(typeDefs, { all: true });

--- a/graphql/server/models/Eatery.js
+++ b/graphql/server/models/Eatery.js
@@ -1,5 +1,5 @@
-import mongoose from "mongoose";
-import { ObjectID } from "mongodb";
+const mongoose = require("mongoose");
+const { ObjectID } = require("mongodb");
 
 const Schema = mongoose.Schema;
 
@@ -34,4 +34,4 @@ const EaterySchema = new Schema({
   ]
 });
 
-export default mongoose.model("Eatery", EaterySchema);
+module.exports = mongoose.model("Eatery", EaterySchema);

--- a/graphql/server/models/User.js
+++ b/graphql/server/models/User.js
@@ -1,5 +1,5 @@
-import mongoose from "mongoose";
-import { ObjectID } from "mongodb";
+const mongoose = require("mongoose");
+const { ObjectID } = require("mongodb");
 
 const Schema = mongoose.Schema;
 
@@ -35,4 +35,4 @@ const UserSchema = new Schema({
   ]
 });
 
-export default mongoose.model("User", UserSchema);
+module.exports = mongoose.model("User", UserSchema);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10790,6 +10790,21 @@
         "@apollographql/apollo-tools": "^0.3.6"
       }
     },
+    "graphql-playground-html": {
+      "version": "1.6.12",
+      "resolved": "https://registry.npmjs.org/graphql-playground-html/-/graphql-playground-html-1.6.12.tgz",
+      "integrity": "sha512-yOYFwwSMBL0MwufeL8bkrNDgRE7eF/kTHiwrqn9FiR9KLcNIl1xw9l9a+6yIRZM56JReQOHpbQFXTZn1IuSKRg==",
+      "dev": true
+    },
+    "graphql-playground-middleware-express": {
+      "version": "1.7.12",
+      "resolved": "https://registry.npmjs.org/graphql-playground-middleware-express/-/graphql-playground-middleware-express-1.7.12.tgz",
+      "integrity": "sha512-17szgonnVSxWVrgblLRHHLjWnMUONfkULIwSunaMvYx8k5oG3yL86cyGCbHuDFUFkyr2swLhdfYl4mDfDXuvOA==",
+      "dev": true,
+      "requires": {
+        "graphql-playground-html": "1.6.12"
+      }
+    },
     "graphql-subscriptions": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/graphql-subscriptions/-/graphql-subscriptions-1.1.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2187,9 +2187,9 @@
           }
         },
         "webpack": {
-          "version": "4.34.0",
-          "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.34.0.tgz",
-          "integrity": "sha512-ry2IQy1wJjOefLe1uJLzn5tG/DdIKzQqNlIAd2L84kcaADqNvQDTBlo8UcCNyDaT5FiaB+16jhAkb63YeG3H8Q==",
+          "version": "4.35.0",
+          "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.35.0.tgz",
+          "integrity": "sha512-M5hL3qpVvtr8d4YaJANbAQBc4uT01G33eDpl/psRTBCfjxFTihdhin1NtAKB1ruDwzeVdcsHHV3NX+QsAgOosw==",
           "dev": true,
           "requires": {
             "@webassemblyjs/ast": "1.8.5",
@@ -3084,9 +3084,9 @@
           }
         },
         "webpack": {
-          "version": "4.34.0",
-          "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.34.0.tgz",
-          "integrity": "sha512-ry2IQy1wJjOefLe1uJLzn5tG/DdIKzQqNlIAd2L84kcaADqNvQDTBlo8UcCNyDaT5FiaB+16jhAkb63YeG3H8Q==",
+          "version": "4.35.0",
+          "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.35.0.tgz",
+          "integrity": "sha512-M5hL3qpVvtr8d4YaJANbAQBc4uT01G33eDpl/psRTBCfjxFTihdhin1NtAKB1ruDwzeVdcsHHV3NX+QsAgOosw==",
           "dev": true,
           "requires": {
             "@webassemblyjs/ast": "1.8.5",
@@ -3437,9 +3437,9 @@
       "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA=="
     },
     "@types/react": {
-      "version": "16.8.20",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.20.tgz",
-      "integrity": "sha512-ZLmI+ubSJpfUIlQuULDDrdyuFQORBuGOvNnMue8HeA0GVrAJbWtZQhcBvnBPNRBI/GrfSfrKPFhthzC2SLEtLQ==",
+      "version": "16.8.22",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.22.tgz",
+      "integrity": "sha512-C3O1yVqk4sUXqWyx0wlys76eQfhrQhiDhDlHBrjER76lR2S2Agiid/KpOU9oCqj1dISStscz7xXz1Cg8+sCQeA==",
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^2.2.0"
@@ -3940,6 +3940,16 @@
       "requires": {
         "apollo-server-env": "2.4.0",
         "graphql-extensions": "0.7.2"
+      },
+      "dependencies": {
+        "graphql-extensions": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.7.2.tgz",
+          "integrity": "sha512-TuVINuAOrEtzQAkAlCZMi9aP5rcZ+pVaqoBI5fD2k5O9fmb8OuXUQOW028MUhC66tg4E7h4YSF1uYUIimbu4SQ==",
+          "requires": {
+            "@apollographql/apollo-tools": "^0.3.6"
+          }
+        }
       }
     },
     "apollo-cache-inmemory": {
@@ -3981,16 +3991,16 @@
       }
     },
     "apollo-engine-reporting": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/apollo-engine-reporting/-/apollo-engine-reporting-1.3.1.tgz",
-      "integrity": "sha512-e0Xp+0yite8DH/xm9fnJt42CxfWAcY6waiq3icCMAgO9T7saXzVOPpl84SkuA+hIJUBtfaKrTnC+7Jxi/I7OrQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/apollo-engine-reporting/-/apollo-engine-reporting-1.3.2.tgz",
+      "integrity": "sha512-Q9XUZ3CTqddjCswlbn+OD2oYxZ5p4lCAnsWOGMfYnSmCXLagyNK28UFFQodjFOy73p6nlTAg9cwaJ9yMOBeeXA==",
       "requires": {
         "apollo-engine-reporting-protobuf": "0.3.1",
-        "apollo-graphql": "^0.3.0",
-        "apollo-server-core": "2.6.3",
+        "apollo-graphql": "^0.3.2",
+        "apollo-server-core": "2.6.4",
         "apollo-server-env": "2.4.0",
         "async-retry": "^1.2.1",
-        "graphql-extensions": "0.7.2"
+        "graphql-extensions": "0.7.3"
       }
     },
     "apollo-engine-reporting-protobuf": {
@@ -4065,12 +4075,12 @@
       }
     },
     "apollo-server": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/apollo-server/-/apollo-server-2.6.3.tgz",
-      "integrity": "sha512-pTIXE5xEMAikKLTIBIqLNvimMETiZbzmiqDb6BGzIUicAz4Rxa1/+bDi1ZeJWrZQjE/TfBLd2Si3qam7dZGrjw==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/apollo-server/-/apollo-server-2.6.4.tgz",
+      "integrity": "sha512-f0TZOc969XNNlSm8sVsU34D8caQfPNwS0oqmWUxb8xXl88HlFzB+HBmOU6ZEKdpMCksTNDbqYo0jXiGJ0rL/0g==",
       "requires": {
-        "apollo-server-core": "2.6.3",
-        "apollo-server-express": "2.6.3",
+        "apollo-server-core": "2.6.4",
+        "apollo-server-express": "2.6.4",
         "express": "^4.0.0",
         "graphql-subscriptions": "^1.0.0",
         "graphql-tools": "^4.0.0"
@@ -4085,23 +4095,23 @@
       }
     },
     "apollo-server-core": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.6.3.tgz",
-      "integrity": "sha512-tfC0QO1NbJW3ShkB5pRCnUaYEkW2AwnswaTeedkfv//EO3yiC/9LeouCK5F22T8stQG+vGjvCqf0C8ldI/XsIA==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.6.4.tgz",
+      "integrity": "sha512-GBF+tQoJ/ysaY2CYMkuuAwJM1nk1yLJumrsBTFfcvalSzS64VdS5VN/zox1eRI+LHQQzHM18HYEAgDGa/EX+gw==",
       "requires": {
         "@apollographql/apollo-tools": "^0.3.6",
         "@apollographql/graphql-playground-html": "1.6.20",
         "@types/ws": "^6.0.0",
         "apollo-cache-control": "0.7.2",
         "apollo-datasource": "0.5.0",
-        "apollo-engine-reporting": "1.3.1",
+        "apollo-engine-reporting": "1.3.2",
         "apollo-server-caching": "0.4.0",
         "apollo-server-env": "2.4.0",
         "apollo-server-errors": "2.3.0",
-        "apollo-server-plugin-base": "0.5.2",
+        "apollo-server-plugin-base": "0.5.3",
         "apollo-tracing": "0.7.2",
         "fast-json-stable-stringify": "^2.0.0",
-        "graphql-extensions": "0.7.2",
+        "graphql-extensions": "0.7.3",
         "graphql-subscriptions": "^1.0.0",
         "graphql-tag": "^2.9.2",
         "graphql-tools": "^4.0.0",
@@ -4126,9 +4136,9 @@
       "integrity": "sha512-rUvzwMo2ZQgzzPh2kcJyfbRSfVKRMhfIlhY7BzUfM4x6ZT0aijlgsf714Ll3Mbf5Fxii32kD0A/DmKsTecpccw=="
     },
     "apollo-server-express": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/apollo-server-express/-/apollo-server-express-2.6.3.tgz",
-      "integrity": "sha512-8ca+VpKArgNzFar0D3DesWnn0g9YDtFLhO56TQprHh2Spxu9WxTnYNjsYs2MCCNf+iV/uy7vTvEknErvnIcZaQ==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/apollo-server-express/-/apollo-server-express-2.6.4.tgz",
+      "integrity": "sha512-U6hiZxty/rait39V5d+QeueNHlwfl68WbYtsutDUVxnq2Jws2ZDrvIkaWWN6HQ77+nBy5gGVxycvWIyoHHfi+g==",
       "requires": {
         "@apollographql/graphql-playground-html": "1.6.20",
         "@types/accepts": "^1.3.5",
@@ -4136,7 +4146,7 @@
         "@types/cors": "^2.8.4",
         "@types/express": "4.17.0",
         "accepts": "^1.3.5",
-        "apollo-server-core": "2.6.3",
+        "apollo-server-core": "2.6.4",
         "body-parser": "^1.18.3",
         "cors": "^2.8.4",
         "graphql-subscriptions": "^1.0.0",
@@ -4145,9 +4155,9 @@
       }
     },
     "apollo-server-plugin-base": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.5.2.tgz",
-      "integrity": "sha512-j81CpadRLhxikBYHMh91X4aTxfzFnmmebEiIR9rruS6dywWCxV2aLW87l9ocD1MiueNam0ysdwZkX4F3D4csNw=="
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.5.3.tgz",
+      "integrity": "sha512-Ax043vQTzPgFeJk6m6hmPm9NMfogO3LlTKJfrWHuyZhPNeTLweHNK30vpdzzgPalcryyDMDfLYFzxuDm0W+rRQ=="
     },
     "apollo-tracing": {
       "version": "0.7.2",
@@ -4156,6 +4166,16 @@
       "requires": {
         "apollo-server-env": "2.4.0",
         "graphql-extensions": "0.7.2"
+      },
+      "dependencies": {
+        "graphql-extensions": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.7.2.tgz",
+          "integrity": "sha512-TuVINuAOrEtzQAkAlCZMi9aP5rcZ+pVaqoBI5fD2k5O9fmb8OuXUQOW028MUhC66tg4E7h4YSF1uYUIimbu4SQ==",
+          "requires": {
+            "@apollographql/apollo-tools": "^0.3.6"
+          }
+        }
       }
     },
     "apollo-utilities": {
@@ -6350,9 +6370,9 @@
       }
     },
     "bser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
-      "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.0.tgz",
+      "integrity": "sha512-8zsjWrQkkBoLK6uxASk1nJ2SKv97ltiGDo6A3wA0/yRPz+CwmEyDo0hUrhIuukG2JHpAl3bvFIixw2/3Hi0DOg==",
       "requires": {
         "node-int64": "^0.4.0"
       }
@@ -6531,9 +6551,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000975",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000975.tgz",
-      "integrity": "sha512-ZsXA9YWQX6ATu5MNg+Vx/cMQ+hM6vBBSqDeJs8ruk9z0ky4yIHML15MoxcFt088ST2uyjgqyUGRJButkptWf0w=="
+      "version": "1.0.30000976",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000976.tgz",
+      "integrity": "sha512-tleNB1IwPRqZiod6nUNum63xQCMN96BUO2JTeiwuRM7p9d616EHsMBjBWJMudX39qCaPuWY8KEWzMZq7A9XQMQ=="
     },
     "capture-exit": {
       "version": "1.2.0",
@@ -8668,9 +8688,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.165",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.165.tgz",
-      "integrity": "sha512-iIS8axR524EAnvUtWUNnREnYjQrS0zUvutIKYgTVuN3MzcjrV31EuJYKw7DGOtFO9DQw+JiXeaVDPQWMskG1wQ=="
+      "version": "1.3.169",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.169.tgz",
+      "integrity": "sha512-CxKt4ONON7m0ekVaFzvTZakHgGQsLMRH0J8W6h4lhyBNgskj3CIJz4bj+bh5+G26ztAe6dZjmYUeEW4u/VSnLQ=="
     },
     "elliptic": {
       "version": "6.4.1",
@@ -10783,9 +10803,9 @@
       }
     },
     "graphql-extensions": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.7.2.tgz",
-      "integrity": "sha512-TuVINuAOrEtzQAkAlCZMi9aP5rcZ+pVaqoBI5fD2k5O9fmb8OuXUQOW028MUhC66tg4E7h4YSF1uYUIimbu4SQ==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.7.3.tgz",
+      "integrity": "sha512-D+FZM0t5gFntJUizeRCurZuUqsyVP13CRejRX+cDJivyGkE6OMWYkCWlzHcbye79q+hYN1m6a3NhlrJRaD9D0w==",
       "requires": {
         "@apollographql/apollo-tools": "^0.3.6"
       }
@@ -10819,9 +10839,9 @@
       "integrity": "sha512-jApXqWBzNXQ8jYa/HLkZJaVw9jgwNqZkywa2zfFn16Iv1Zb7ELNHkJaXHR7Quvd5SIGsy6Ny7SUKATgnu05uEg=="
     },
     "graphql-tools": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-4.0.4.tgz",
-      "integrity": "sha512-chF12etTIGVVGy3fCTJ1ivJX2KB7OSG4c6UOJQuqOHCmBQwTyNgCDuejZKvpYxNZiEx7bwIjrodDgDe9RIkjlw==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-4.0.5.tgz",
+      "integrity": "sha512-kQCh3IZsMqquDx7zfIGWBau42xe46gmqabwYkpPlCLIjcEY1XK+auP7iGRD9/205BPyoQdY8hT96MPpgERdC9Q==",
       "requires": {
         "apollo-link": "^1.2.3",
         "apollo-utilities": "^1.0.1",
@@ -11267,6 +11287,13 @@
         "setprototypeof": "1.1.1",
         "statuses": ">= 1.5.0 < 2",
         "toidentifier": "1.0.0"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        }
       }
     },
     "http-parser-js": {
@@ -11464,9 +11491,9 @@
       }
     },
     "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
       "version": "1.3.5",
@@ -11474,9 +11501,9 @@
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "inquirer": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.3.1.tgz",
-      "integrity": "sha512-MmL624rfkFt4TG9y/Jvmt8vdmOo836U7Y0Hxr2aFk3RelZEGX4Igk0KabWrcaaZaTv9uzglOqWh1Vly+FAWAXA==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.4.1.tgz",
+      "integrity": "sha512-/Jw+qPZx4EDYsaT6uz7F4GJRNFMRdKNeUZw3ZnKV8lyuUgz/YWRCSUAJMZSVhSq4Ec0R2oYnyi6b3d4JXcL5Nw==",
       "requires": {
         "ansi-escapes": "^3.2.0",
         "chalk": "^2.4.2",
@@ -11690,10 +11717,14 @@
       "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE="
     },
     "is-dom": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/is-dom/-/is-dom-1.0.9.tgz",
-      "integrity": "sha1-SDgy1SlyBz3hK5/j9gMghw2oNw0=",
-      "dev": true
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-dom/-/is-dom-1.1.0.tgz",
+      "integrity": "sha512-u82f6mvhYxRPKpw8V1N0W8ce1xXwOrQtgGcxl6UCL5zBmZu3is/18K0rR7uFCnMDuAsS/3W54mGL4vsaFUQlEQ==",
+      "dev": true,
+      "requires": {
+        "is-object": "^1.0.1",
+        "is-window": "^1.0.2"
+      }
     },
     "is-dotfile": {
       "version": "1.0.3",
@@ -11780,6 +11811,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
+    },
+    "is-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
+      "dev": true
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -11893,6 +11930,12 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+    },
+    "is-window": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-window/-/is-window-1.0.2.tgz",
+      "integrity": "sha1-LIlspT25feRdPDMTOmXYyfVjSA0=",
+      "dev": true
     },
     "is-windows": {
       "version": "1.0.2",
@@ -15001,11 +15044,11 @@
       "dev": true
     },
     "nodemon": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-1.19.1.tgz",
-      "integrity": "sha512-/DXLzd/GhiaDXXbGId5BzxP1GlsqtMGM9zTmkWrgXtSqjKmGSbLicM/oAy4FR0YWm14jCHRwnR31AHS2dYFHrg==",
+      "version": "1.18.9",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-1.18.9.tgz",
+      "integrity": "sha512-oj/eEVTEI47pzYAjGkpcNw0xYwTl4XSTUQv2NPQI6PpN3b75PhpuYk3Vb3U80xHCyM2Jm+1j68ULHXl4OR3Afw==",
       "requires": {
-        "chokidar": "^2.1.5",
+        "chokidar": "^2.0.4",
         "debug": "^3.1.0",
         "ignore-by-default": "^1.0.1",
         "minimatch": "^3.0.4",
@@ -16481,11 +16524,11 @@
       }
     },
     "postcss-custom-properties": {
-      "version": "8.0.10",
-      "resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-8.0.10.tgz",
-      "integrity": "sha512-GDL0dyd7++goDR4SSasYdRNNvp4Gqy1XMzcCnTijiph7VB27XXpJ8bW/AI0i2VSBZ55TpdGhMr37kMSpRfYD0Q==",
+      "version": "8.0.11",
+      "resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-8.0.11.tgz",
+      "integrity": "sha512-nm+o0eLdYqdnJ5abAJeXp4CEU1c1k+eB2yMCvhgzsds/e0umabFrN6HoTy/8Q4K5ilxERdl/JD1LO5ANoYBeMA==",
       "requires": {
-        "postcss": "^7.0.14",
+        "postcss": "^7.0.17",
         "postcss-values-parser": "^2.0.1"
       },
       "dependencies": {
@@ -19851,9 +19894,9 @@
       "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
     },
     "process-nextick-args": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "progress": {
       "version": "2.0.3",
@@ -19969,9 +20012,9 @@
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "psl": {
-      "version": "1.1.32",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.32.tgz",
-      "integrity": "sha512-MHACAkHpihU/REGGPLj4sEfc/XKW2bheigvHO1dUqjaKigMp1C8+WLQYRGgeKFMsw5PMfegZcaN8IDXK/cD0+g=="
+      "version": "1.1.33",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.33.tgz",
+      "integrity": "sha512-LTDP2uSrsc7XCb5lO7A8BI1qYxRe/8EqlRvMeEl6rsnYAqDOl8xHR+8lSAIVfrNaSAlTPTNOCgNjWcoUL3AZsw=="
     },
     "pstree.remy": {
       "version": "1.1.7",
@@ -21758,9 +21801,9 @@
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "resolve": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.0.tgz",
-      "integrity": "sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
+      "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
       "requires": {
         "path-parse": "^1.0.6"
       }
@@ -22286,6 +22329,11 @@
             "setprototypeof": "1.1.0",
             "statuses": ">= 1.4.0 < 2"
           }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "setprototypeof": {
           "version": "1.1.0",
@@ -24310,6 +24358,13 @@
       "integrity": "sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==",
       "requires": {
         "inherits": "2.0.3"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        }
       }
     },
     "util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "graphql-tools": "^4.0.4",
     "merge-graphql-schemas": "^1.5.8",
     "mongoose": "^5.4.9",
-    "nodemon": "^1.18.9",
+    "nodemon": "1.18.9",
     "open": "^6.2.0",
     "open-cli": "^1.0.5",
     "react": "^16.8.1",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "file-loader": "^3.0.1",
     "fs": "0.0.1-security",
     "graphql": "^14.3.1",
+    "graphql-playground-middleware-express": "^1.7.12",
     "html-webpack-plugin": "^3.2.0",
     "https": "^1.0.0",
     "node-sass": "4.11.0",
@@ -91,5 +92,10 @@
     "not dead",
     "not ie <= 11",
     "not op_mini all"
-  ]
+  ],
+  "babel": {
+    "presets": [
+      "latest"
+    ]
+  }
 }


### PR DESCRIPTION
Introduces Apollo's playground IDE for GraphQL.

Switched out `GraphiQL` for `Playground`.

Hooked up the MongoDB to it.

Devolved to ES5 syntax rather than wiring up the GQL server schemas (types/resolvers) through Webpack.

**Issues**
Will need to further investigate why ES6 started failing after switching to Apollo Playground.